### PR TITLE
Fix `U+06CC` character bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,6 +7,8 @@ doubleDots = ["ت", "ق"],
 tripleDots = ["پ", "ث", "چ", "ژ", "ش"],
 midLetterDots = ["ی"];
 
+const persianLettersRegex = /^[آابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهی]+$/;
+
 // input and result tags
 inputTag = document.getElementById("text"),
 result = document.getElementById("dots");
@@ -33,7 +35,7 @@ function dotCounter(text) {
 
         // Check for letters that only have dots in the middle of the string
         if (midLetterDots.includes(letter) && i !== spText.length - 1) {
-            if (spText[i+1] !== " ") {
+            if (spText[i+1] && persianLettersRegex.test(spText[i+1])) {
                 dotsCount+= 2;
             }
         }

--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ doubleDots = ["ت", "ق"],
 tripleDots = ["پ", "ث", "چ", "ژ", "ش"],
 midLetterDots = ["ی"];
 
-const persianLettersRegex = /^[آابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهی]+$/;
+const persianLettersRegex = /^[آابپتثجچحخدذرزژسشصضطظعغفقکگلمنوهیـ]+$/;
 
 // input and result tags
 inputTag = document.getElementById("text"),


### PR DESCRIPTION
This will fix the dot counting bug of the character `U+06CC` (or `ی`)

- Non-Persian and numeric characters after `ی` wont effect the counting
- The character `U+0640` known as Arabic Tatweel (which is `ـ`) will effect the results when combined with `ی` (which produces `یـ`)